### PR TITLE
feat: Add base for error handling (OnBadLines and AbstractToIonConverter)

### DIFF
--- a/src/main/java/io/kestra/plugin/serdes/AbstractToIonConverter.java
+++ b/src/main/java/io/kestra/plugin/serdes/AbstractToIonConverter.java
@@ -1,0 +1,32 @@
+package io.kestra.plugin.serdes;
+
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.Task;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class AbstractToIonConverter extends Task {
+
+    @NotNull
+    @PluginProperty(internalStorageURI = true)
+    /*
+     * Location (URI) of the input file as every ToIon task needs to have an input file
+     */
+
+    protected Property<String> from;
+
+    @Builder.Default
+    @PluginProperty
+    // The behavior when a line can't be parsed (ex. corrupted format)
+
+    protected final Property<OnBadLines> onBadLines = Property.ofValue(OnBadLines.ERROR);
+
+}

--- a/src/main/java/io/kestra/plugin/serdes/OnBadLines.java
+++ b/src/main/java/io/kestra/plugin/serdes/OnBadLines.java
@@ -1,0 +1,11 @@
+package io.kestra.plugin.serdes;
+
+public enum OnBadLines {
+
+    ERROR, // Raise an exception immediately when a bad line is encountered, stopping the task.
+
+    WARN, // Log a warning and skip the bad line.
+
+    SKIP; // Skip bad lines silently without raising an error or warning.
+
+}


### PR DESCRIPTION
Added two files that allows control on how Kestra will handle corrupted lines when reading data files such as CSV, JSON, etc.

1. OnBadLines.java : Have the three options that users will have for errors: ERROR, WARN, or SKIP.

2. AbstractToIonConverter.java: Base file that gives the onBadLines settings to all existing ToIon tasks at once which will prevent needing to duplicate the code

Introduces the base structure to allow the users to select how data reading tasks should react to corrupted lines. This PR only contains the base code (abstract classes and enums), so testing will be have to be completed in the next PR where the actual implementation is tested